### PR TITLE
Feat/handle json errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,16 @@
         "title": "Remove from context"
       }
     ],
-    "menus": {
+    "menus": {      
       "explorer/context": [
         {
           "command": "context-organizer.addToFileSection",
           "when": "resourceLangId != undefined"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "context-organizer.addToFileSection"          
         }
       ],
       "view/title": [

--- a/src/comands.ts
+++ b/src/comands.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { SimpleDataProvider } from './dataProvider';
+import { SingletonOutputChannel } from './loggerChannel';
 
 export async function showSectionPicker(): Promise<string | undefined> {
 	const workspaceRoot = vscode.workspace.rootPath;
@@ -9,7 +10,17 @@ export async function showSectionPicker(): Promise<string | undefined> {
 
 	if (fs.existsSync(configPath)) {
 		const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+		 
 		const sections = Object.keys(config.contexts);
+
+		if (sections.length===0){
+			let message='File contexts.json in .vscode does not contain any folder. Create firsts a folder to add the selected file.';
+			SingletonOutputChannel.appendLine(message);
+
+			vscode.window.showWarningMessage(message);
+			return undefined;
+		}
+
 		return await vscode.window.showQuickPick(sections, {
 			placeHolder: 'Select a context to add the file to'
 		});
@@ -29,6 +40,10 @@ export function addFileToConfig(filePath: string, section: string, dataProvider:
 		const fileContent = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 
 		if (fileContent.contexts[section]) {
+			if (fileContent.contexts[section].includes(relativePath)){
+				vscode.window.showWarningMessage(`File:${relativePath} already exists in context ${section}.`);
+				return;
+			}
 			fileContent.contexts[section].push(relativePath);
 			fs.writeFileSync(configPath, JSON.stringify(fileContent, null, 4));
 			dataProvider.refresh();

--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -1,20 +1,15 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-
+import {SingletonOutputChannel} from './loggerChannel';
 export class SimpleDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 	private _items: vscode.TreeItem[] = [];
 
 	constructor(private workspaceRoot: string) {
 		this.loadConfig();
 	}
-
-	private loadConfig() {
-		this._items = [];
-		const configPath = path.join(this.workspaceRoot, '.vscode', 'contexts.json');
-
-		if (fs.existsSync(configPath)) {
-			const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+	private handleLoadConfig(configPath:string){
+		const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 			const showFolders = config.configs.showFolders;
 
 			for (const sectionName in config.contexts) {
@@ -25,6 +20,25 @@ export class SimpleDataProvider implements vscode.TreeDataProvider<vscode.TreeIt
 					}
 				}
 				this._items.push(new Section(sectionName, sectionItems));
+			}
+	}
+	private loadConfig() {
+		this._items = [];
+		const configPath = path.join(this.workspaceRoot, '.vscode', 'contexts.json');
+		
+		if (fs.existsSync(configPath)) {
+			try{
+				this.handleLoadConfig(configPath);
+			}catch(error){
+				let message = `Error while reading file ${configPath}, check your file`;
+				vscode.window.showErrorMessage(message); //not detailed error
+				if (error instanceof SyntaxError){ 
+					message = `Error while reading file configPath, details : ${error.message}`;
+				}				 
+				SingletonOutputChannel.appendLine(message);
+
+				
+				
 			}
 		} else {
 			vscode.window.showWarningMessage('File contexts.json in .vscode folder not found.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { SimpleDataProvider, File } from './dataProvider';
 import { showSectionPicker, addFileToConfig, createDefaultContextsFile } from './comands'
+import { SingletonOutputChannel } from './loggerChannel';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -66,6 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	});
 	context.subscriptions.push(removeFileFromContext);
+	SingletonOutputChannel.getInstance();
 }
 
 export function deactivate() { }

--- a/src/loggerChannel.ts
+++ b/src/loggerChannel.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+
+export class SingletonOutputChannel {
+    private static instance: vscode.OutputChannel;
+ 
+    private constructor() { }
+ 
+    public static getInstance(): vscode.OutputChannel {
+        if (!SingletonOutputChannel.instance) {
+            SingletonOutputChannel.instance = vscode.window.createOutputChannel("context-organizer");
+            SingletonOutputChannel.instance.show();
+
+        }
+
+        return SingletonOutputChannel.instance;
+    }
+
+    public static appendLine(value:string){
+        if (!this.instance){
+            SingletonOutputChannel.getInstance();
+        }
+        const timestamp = new Date().toISOString();        
+        this.instance.appendLine(`${timestamp} - ${value}`);        	
+    }
+     
+}


### PR DESCRIPTION
This pull request include 3 modifications listed below:


1.Handling error when parsing Json file contexts.json when after adding the more than once to a "context" produces an SyntaxError (I reproduce this error by adding the same file to context which already have the file in the list)  and 2 implemented channel show log errors:
 
![image](https://github.com/devaniljr/context-organizer/assets/21212423/bde28ce7-6ffa-4301-b63f-649b6d7635e0)

In this case I force to corrupt the JSON to reproduce this error.

3. Add a validation to prevent adding the same file more than once and showing a message to the user:
 
![image](https://github.com/devaniljr/context-organizer/assets/21212423/18497127-258f-4517-ac85-e23070190ef7)

- Adding the command "add to context" in the editor context menu :
![image](https://github.com/devaniljr/context-organizer/assets/21212423/1ebde85e-fc06-49b7-aa6b-69107c207592)


Any question or suggestion for this PR is fine, I really like this extension.


